### PR TITLE
Convert HTML Content extracted by Wallabag to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Use the command "Sync Wallabag Articles" to sync new articles. Plugin will keep 
 
 There are various settings under the plugin settings you can use to personalize your workflow, here are some important ones:
 
-| Setting  |  Decsription |
-|:--|:--|
-|Tag to sync | Use this for syncing only the articles tagged with tag. If empty plugin will sync all the articles.  |
-|Article Notes Folder | Define the folder you want synced notes will be created. If empty notes will be created at the vault root.   |
-|Article Note Template  | Use to pass a custom template for notes. See the [Templating](#templating) for more details.  |
-| Export as PDF | If enabled synced articles will be exported as PDFs.|
-
+| Setting                                                | Decsription                                                                                                         |
+| :----------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| Tag to sync                                            | Use this for syncing only the articles tagged with tag. If empty plugin will sync all the articles.                 |
+| Article Notes Folder                                   | Define the folder you want synced notes will be created. If empty notes will be created at the vault root.          |
+| Article Note Template                                  | Use to pass a custom template for notes. See the [Templating](#templating) for more details.                        |
+| Export as PDF                                          | If enabled synced articles will be exported as PDFs.                                                                |
+| Convert HTML Content extracted by Wallabag to Markdown | If enabled the content of the Wallabag article will be converted to markdown before being used for the new article. |
 
 ## Templating
 
@@ -32,14 +32,14 @@ By default this plugin offers two builtin templates; one for inserting the conte
 ![](screenshots/ss1.png)
 
 You can use a custom template, in that case plugin will pass the following variables.
-| Variable        | Description                                                                                                        |
+| Variable | Description |
 |:----------------|:-------------------------------------------------------------------------------------------------------------------|
-| `article_title` | Title of the article                                                                                               |
-| `original_link` | Link to the source article                                                                                         |
-| `wallabag_link` | Link to the article in Wallabag                                                                                    |
-| `content`       | HTML content extracted by wallabag                                                                                 |
-| `pdf_link`      | An Obsidian wikilink to the exported pdf file. <sub><br> Only populated if the PDF export option is choosen.</sub> |
-| `tags`          | Comma separated list of tags attached to the Wallabag article                                                      |
+| `article_title` | Title of the article |
+| `original_link` | Link to the source article |
+| `wallabag_link` | Link to the article in Wallabag |
+| `content` | HTML content extracted by wallabag |
+| `pdf_link` | An Obsidian wikilink to the exported pdf file. <sub><br> Only populated if the PDF export option is choosen.</sub> |
+| `tags` | Comma separated list of tags attached to the Wallabag article |
 
 I mainly use the template to export pdfs and use [Annotator]() to read using the following template.
 
@@ -51,13 +51,12 @@ annotation-target: {{pdf_link}}
 
 ![](screenshots/ss2.png)
 
-
 ## Installation
 
 ### Manually
 
 - You need Obsidian v1.0.0+ for latest version of plugin
-- Get the [Latest release of the plugin](https://github.com/huseyz/obsidian-wallabag/releases/latest) 
+- Get the [Latest release of the plugin](https://github.com/huseyz/obsidian-wallabag/releases/latest)
 - Extract the files in your vault's plugins folder: `[VAULT]/.obsidian/plugins/`
 - Reload Obsidian
 - Make sure Safe Mode is off and the plugins is enabled.

--- a/src/command/SyncArticlesCommand.ts
+++ b/src/command/SyncArticlesCommand.ts
@@ -63,7 +63,7 @@ export default class SyncArticlesCommand implements Command {
         if (this.plugin.settings.downloadAsPDF !== 'true') {
           const template = this.plugin.settings.articleTemplate === '' ? DefaultTemplate : await this.getUserTemplate();
           const filename = path.join(this.plugin.settings.folder, `${this.getFilename(article)}.md`);
-          const content = template.fill(article, this.plugin.settings.serverUrl);
+          const content = template.fill(article, this.plugin.settings.serverUrl, this.plugin.settings.convertHtmlToMarkdown);
           await this.createNoteIfNotExists(filename, content);
           return article.id;
         } else {

--- a/src/note/NoteTemplate.ts
+++ b/src/note/NoteTemplate.ts
@@ -1,4 +1,5 @@
 import { WallabagArticle } from 'wallabag/WallabagAPI';
+import { htmlToMarkdown } from 'obsidian';
 
 export default class NoteTemplate {
   content: string;
@@ -7,12 +8,12 @@ export default class NoteTemplate {
     this.content = content;
   }
 
-  fill(wallabagArticle: WallabagArticle, serverBaseUrl: string, pdfLink = ''): string {
+  fill(wallabagArticle: WallabagArticle, serverBaseUrl: string, convertHtmlToMarkdown: string, pdfLink = ''): string {
     const variables: {[key: string]: string} = {
       '{{article_title}}': wallabagArticle.title,
       '{{original_link}}': wallabagArticle.url,
       '{{wallabag_link}}': `${serverBaseUrl}/view/${wallabagArticle.id}`,
-      '{{content}}': wallabagArticle.content,
+      '{{content}}': convertHtmlToMarkdown === 'true' ? htmlToMarkdown(wallabagArticle.content) : wallabagArticle.content,
       '{{pdf_link}}': pdfLink,
       '{{tags}}': wallabagArticle.tags.join(', ')
     };

--- a/src/settings/WallabagSettingTab.ts
+++ b/src/settings/WallabagSettingTab.ts
@@ -94,6 +94,17 @@ export class WallabagSettingTab extends PluginSettingTab {
         });
       });
 
+    new Setting(this.containerEl)
+      .setName('Convert HTML Content extracted by Wallabag to Markdown')
+      .setDesc('If enabled the content of the Wallabag article will be converted to markdown before being used for the new article.')
+      .addToggle(async (toggle) => {
+        toggle.setValue(this.plugin.settings.convertHtmlToMarkdown === 'true');
+        toggle.onChange(async (value) => {
+          this.plugin.settings.convertHtmlToMarkdown = String(value);
+          await this.plugin.saveSettings();
+        });
+      });
+
     this.authenticationSettings();
   }
 

--- a/src/settings/WallabagSettings.ts
+++ b/src/settings/WallabagSettings.ts
@@ -6,6 +6,7 @@ export interface WallabagSettings {
   articleTemplate: string;
   pdfFolder: string;
   createPDFNote: string;
+  convertHtmlToMarkdown: string
 }
 
 export const DEFAULT_SETTINGS: WallabagSettings = {
@@ -15,5 +16,6 @@ export const DEFAULT_SETTINGS: WallabagSettings = {
   downloadAsPDF: 'false',
   articleTemplate: '',
   pdfFolder: '',
-  createPDFNote: 'false'
+  createPDFNote: 'false',
+  convertHtmlToMarkdown: 'false'
 };


### PR DESCRIPTION
Added an option to convert HTML from wallabag to markdown, before creating the note in obsidian.
Don't know if it is a feature you would like to add to the plugin?  Feel free to comment...

btw, thanks for this plugin! It really is a good addition to my PKM.