### PR TITLE
Change request method for refresh token and add option for template

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can use a custom template, in that case plugin will pass the following varia
 |:----------------|:-------------------------------------------------------------------------------------------------------------------|
 | `article_title` | Title of the article |
 | `original_link` | Link to the source article |
+| `created_at` | Creation date of the article in Wallabag |
 | `wallabag_link` | Link to the article in Wallabag |
 | `content` | HTML content extracted by wallabag |
 | `pdf_link` | An Obsidian wikilink to the exported pdf file. <sub><br> Only populated if the PDF export option is choosen.</sub> |

--- a/src/note/NoteTemplate.ts
+++ b/src/note/NoteTemplate.ts
@@ -12,6 +12,7 @@ export default class NoteTemplate {
     const variables: {[key: string]: string} = {
       '{{article_title}}': wallabagArticle.title,
       '{{original_link}}': wallabagArticle.url,
+      '{{created_at}}': wallabagArticle.createdAt,
       '{{wallabag_link}}': `${serverBaseUrl}/view/${wallabagArticle.id}`,
       '{{content}}': convertHtmlToMarkdown === 'true' ? htmlToMarkdown(wallabagArticle.content) : wallabagArticle.content,
       '{{pdf_link}}': pdfLink,

--- a/src/settings/WallabagSettingTab.ts
+++ b/src/settings/WallabagSettingTab.ts
@@ -50,6 +50,7 @@ export class WallabagSettingTab extends PluginSettingTab {
           'The template file that will be used for the new articles.<br> ' +
           '<code>{{article_title}}</code>: Title of the article.<br>' +
           '<code>{{original_link}}</code>: Link to the original article.<br>' +
+          '<code>{{created_at}}</code>: Creation date of the article in Wallabag.<br>' +
           '<code>{{wallabag_link}}</code>: Link to the Wallabag article.<br>' +
           '<code>{{content}}</code>: HTML Content extracted by Wallabag. <br>' +
           '<code>{{pdf_link}}</code>: An Obsidian link to the exported pdf.' +

--- a/src/wallabag/WallabagAPI.ts
+++ b/src/wallabag/WallabagAPI.ts
@@ -54,7 +54,10 @@ export default class WallabagAPI {
 
   async refresh(): Promise<Token> {
     return request({
-      url: `${this.plugin.settings.serverUrl}/oauth/v2/token?grant_type=refresh_token&refresh_token=${this.token.refreshToken}&client_id=${this.token.clientId}&client_secret=${this.token.clientSecret}`
+      url: `${this.plugin.settings.serverUrl}/oauth/v2/token`,
+      method: 'POST',
+      body: `grant_type=refresh_token&refresh_token=${this.token.refreshToken}&client_id=${this.token.clientId}&client_secret=${this.token.clientSecret}`,
+      contentType: 'application/x-www-form-urlencoded',
     }).then((response) => {
       const parsed = JSON.parse(response);
       return {


### PR DESCRIPTION
Fix #11

And add the ability to use wallabag's article creation date inside a template.
Date will be formated as below : 
![image](https://user-images.githubusercontent.com/31347719/233488507-86dc36cd-8e24-4752-88c4-078bedee1aac.png)
