### PR TITLE
Refactor API request to use JSON format

### DIFF
--- a/src/wallabag/WallabagAPI.ts
+++ b/src/wallabag/WallabagAPI.ts
@@ -36,20 +36,30 @@ export default class WallabagAPI {
     username: string,
     password: string
   ): Promise<Token> {
-    return request({
+    const body = {
+      grant_type: 'password',
+      client_id: clientId,
+      client_secret: clientSecret,
+      username,
+      password
+    };
+
+    const requestOptions = {
       url: `${serverUrl}/oauth/v2/token`,
       method: 'POST',
-      body: `grant_type=password&client_id=${clientId}&client_secret=${clientSecret}&username=${username}&password=${password}`,
-      contentType: 'application/x-www-form-urlencoded',
-    }).then((response) => {
-      const parsed = JSON.parse(response);
-      return {
-        clientId: clientId,
-        clientSecret: clientSecret,
-        accessToken: parsed.access_token,
-        refreshToken: parsed.refresh_token,
-      };
-    });
+      body: JSON.stringify(body),
+      contentType: 'application/json',
+    };
+
+    const response = await request(requestOptions);
+    const parsed = JSON.parse(response);
+
+    return {
+      clientId,
+      clientSecret,
+      accessToken: parsed.access_token,
+      refreshToken: parsed.refresh_token,
+    };
   }
 
   async refresh(): Promise<Token> {


### PR DESCRIPTION
Updated the Wallabag API to send the request body in JSON format from 'application/x-www-form-urlencoded'. This change has been done in order to improve the authentication process if there are problematic characters in the password/username.