### PR TITLE
Add annotation support to Wallabag articles

### DIFF
--- a/src/note/NoteTemplate.ts
+++ b/src/note/NoteTemplate.ts
@@ -9,6 +9,7 @@ export default class NoteTemplate {
   }
 
   fill(wallabagArticle: WallabagArticle, serverBaseUrl: string, convertHtmlToMarkdown: string, tagFormat: string, pdfLink = ''): string {
+    const annotations = wallabagArticle.annotations.map(a => '> ' + a.quote).join('\n\n');
     const variables: {[key: string]: string} = {
       '{{article_title}}': wallabagArticle.title,
       '{{original_link}}': wallabagArticle.url,
@@ -19,7 +20,8 @@ export default class NoteTemplate {
       '{{tags}}': this.formatTags(wallabagArticle.tags, tagFormat),
       '{{reading_time}}': wallabagArticle.readingTime,
       '{{preview_picture}}': wallabagArticle.previewPicture,
-      '{{domain_name}}': wallabagArticle.domainName
+      '{{domain_name}}': wallabagArticle.domainName,
+      '{{annotations}}': annotations
     };
     let content = this.content;
     Object.keys(variables).forEach((key) => {

--- a/src/note/NoteTemplate.ts
+++ b/src/note/NoteTemplate.ts
@@ -9,7 +9,7 @@ export default class NoteTemplate {
   }
 
   fill(wallabagArticle: WallabagArticle, serverBaseUrl: string, convertHtmlToMarkdown: string, tagFormat: string, pdfLink = ''): string {
-    const annotations = wallabagArticle.annotations.map(a => '> ' + a.quote).join('\n\n');
+    const annotations = wallabagArticle.annotations.map(a => '> ' + a.quote + (a.text ? '\n\n' + a.text : '')).join('\n\n');
     const variables: {[key: string]: string} = {
       '{{article_title}}': wallabagArticle.title,
       '{{original_link}}': wallabagArticle.url,

--- a/src/settings/WallabagSettingTab.ts
+++ b/src/settings/WallabagSettingTab.ts
@@ -57,7 +57,8 @@ export class WallabagSettingTab extends PluginSettingTab {
           '<code>{{tags}}</code>: Tags of the article.<br>' +
           '<code>{{reading_time}}</code>: Reading time of the article.<br>' +
           '<code>{{preview_picture}}</code>: Preview picture of the article.<br>' +
-          '<code>{{domain_name}}</code>: Domain name of the article.<br>'
+          '<code>{{domain_name}}</code>: Domain name of the article.<br>' +
+          '<code>{{annotations}}</code>: Created annotations of the article.<br>'
         ),
         get: () => this.plugin.settings.articleTemplate,
         set: this.updateSetting('articleTemplate')

--- a/src/wallabag/WallabagAPI.ts
+++ b/src/wallabag/WallabagAPI.ts
@@ -2,6 +2,16 @@ import WallabagPlugin from 'main';
 import { request, requestUrl, RequestUrlResponse } from 'obsidian';
 import { Token } from './WallabagAuth';
 
+interface WallabagAnnotation {
+  user: string,
+  annotator_schema_version: string,
+  id: number,
+  text: string,
+  created_at: string,
+  updated_at: string,
+  quote: string,
+}
+
 export interface WallabagArticle {
   id: number,
   tags: string[],
@@ -12,6 +22,7 @@ export interface WallabagArticle {
   readingTime: string,
   previewPicture: string,
   domainName: string
+  annotations: WallabagAnnotation[]
 }
 
 export interface WallabagArticlesResponse {
@@ -79,7 +90,8 @@ export default class WallabagAPI {
       createdAt: article['created_at'],
       readingTime: article['reading_time'],
       previewPicture: article['preview_picture'],
-      domainName: article['domain_name']
+      domainName: article['domain_name'],
+      annotations: article['annotations'],
     };
   }
 


### PR DESCRIPTION
This commit introduces a new feature that adds annotations to Wallabag articles. The 'fill' function in NoteTemplate.ts file now maps and joins each annotation from a Wallabag article. A new variable called 'annotations' is defined to store these values. The interface 'WallabagArticle' in WallabagAPI.ts has been extended to include 'annotations'. User guidance on this feature has been added in WallabagSettingTab.ts file. This feature will enrich the notes created with useful annotations.