### PR TITLE
Expose more templating fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ By default this plugin offers two builtin templates; one for inserting the conte
 You can use a custom template, in that case plugin will pass the following variables.
 | Variable | Description |
 |:----------------|:-------------------------------------------------------------------------------------------------------------------|
+| `id` | Wallabag ID of the article (Useful for scripting) |
 | `article_title` | Title of the article |
 | `original_link` | Link to the source article |
 | `created_at` | Creation date of the article in Wallabag |
+| `published_at` | When the article was originally published according to Wallabag |
+| `updated_at` | Last modification date of the article in Wallabag <sub><br>Wallabag API seems not to change this field when modifying annotations.</sub> |
 | `wallabag_link` | Link to the article in Wallabag |
 | `content` | HTML content extracted by wallabag |
 | `pdf_link` | An Obsidian wikilink to the exported pdf file. <sub><br> Only populated if the PDF export option is choosen.</sub> |

--- a/src/note/NoteTemplate.ts
+++ b/src/note/NoteTemplate.ts
@@ -11,9 +11,12 @@ export default class NoteTemplate {
   fill(wallabagArticle: WallabagArticle, serverBaseUrl: string, convertHtmlToMarkdown: string, tagFormat: string, pdfLink = ''): string {
     const annotations = wallabagArticle.annotations.map(a => '> ' + a.quote + (a.text ? '\n\n' + a.text : '')).join('\n\n');
     const variables: {[key: string]: string} = {
+      '{{id}}': wallabagArticle.id.toString(),
       '{{article_title}}': wallabagArticle.title,
       '{{original_link}}': wallabagArticle.url,
       '{{created_at}}': wallabagArticle.createdAt,
+      '{{published_at}}': wallabagArticle.publishedAt,
+      '{{updated_at}}': wallabagArticle.updatedAt,
       '{{wallabag_link}}': `${serverBaseUrl}/view/${wallabagArticle.id}`,
       '{{content}}': convertHtmlToMarkdown === 'true' ? htmlToMarkdown(wallabagArticle.content) : wallabagArticle.content,
       '{{pdf_link}}': pdfLink,

--- a/src/settings/WallabagSettingTab.ts
+++ b/src/settings/WallabagSettingTab.ts
@@ -47,17 +47,7 @@ export class WallabagSettingTab extends PluginSettingTab {
         name: 'Article note template file',
         desc: sanitizeHTMLToDom(
           'The template file that will be used for the new articles.<br> ' +
-          '<code>{{article_title}}</code>: Title of the article.<br>' +
-          '<code>{{original_link}}</code>: Link to the original article.<br>' +
-          '<code>{{created_at}}</code>: Creation date of the article in Wallabag.<br>' +
-          '<code>{{wallabag_link}}</code>: Link to the Wallabag article.<br>' +
-          '<code>{{content}}</code>: HTML Content extracted by Wallabag. <br>' +
-          '<code>{{pdf_link}}</code>: An Obsidian link to the exported pdf.' +
-          '<code>{{tags}}</code>: Tags of the article.<br>' +
-          '<code>{{reading_time}}</code>: Reading time of the article.<br>' +
-          '<code>{{preview_picture}}</code>: Preview picture of the article.<br>' +
-          '<code>{{domain_name}}</code>: Domain name of the article.<br>' +
-          '<code>{{annotations}}</code>: Created annotations of the article.<br>'
+          'See <a href="https://github.com/huseyz/obsidian-wallabag">documentation</a> for examples.'
         ),
         get: () => this.plugin.settings.articleTemplate,
         set: this.updateSetting('articleTemplate')

--- a/src/wallabag/WallabagAPI.ts
+++ b/src/wallabag/WallabagAPI.ts
@@ -19,6 +19,8 @@ export interface WallabagArticle {
   url: string,
   content: string,
   createdAt: string,
+  publishedAt: string;
+  updatedAt: string;
   readingTime: string,
   previewPicture: string,
   domainName: string
@@ -98,6 +100,8 @@ export default class WallabagAPI {
       url: article['url'],
       content: article['content'],
       createdAt: article['created_at'],
+      updatedAt: article['updated_at'],
+      publishedAt: article['published_at'],
       readingTime: article['reading_time'],
       previewPicture: article['preview_picture'],
       domainName: article['domain_name'],


### PR DESCRIPTION
Some more fields you can use in frontmatter for example. I can imagine the `id` field being useful for your work maybe @gwutz (So you re-fetch specific articles by id). The `updated_at` field also seemed interesting for syncing purposes (only overwrite article when `last_updated` in frontmatter differs from what the API returns) but unfortunately it doesn't increment when adding or editing annotations.