### PR TITLE
Delete note and remove it from synced items cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can follow the Wallabag's [iOS Setup guide](https://doc.wallabag.org/en/apps
 
 This plugin fulfills a qiute straightforward purpose; it syncs Wallabag articles and creates notes from them in various possible formats.
 
-Use the command "Sync Wallabag Articles" to sync new articles. Plugin will keep a track of items synced so if you delete a created note, it won't be generated again unless you use the command "Clear synced articles cache" to reset the plugin cache.
+Use the command "Sync Wallabag Articles" to sync new articles. Plugin will keep a track of items synced so if you delete a created note, it won't be generated again unless you use the command "Clear synced articles cache" to reset the plugin cache. There is also a "Delete note and remove it from synced articles cache" command to remove an individual note from both the file system and synced article cache. This is useful to fetch any changes you made to the note in Wallabag (such as tags and annotations).
 
 There are various settings under the plugin settings you can use to personalize your workflow, here are some important ones:
 
@@ -37,12 +37,12 @@ By default this plugin offers two builtin templates; one for inserting the conte
 You can use a custom template, in that case plugin will pass the following variables.
 | Variable | Description |
 |:----------------|:-------------------------------------------------------------------------------------------------------------------|
-| `id` | Wallabag ID of the article (Useful for scripting) |
+| `id` | Wallabag ID of the article <sub><br>Add this to your notes frontmatter using the `wallabag_id` key to make use of the 'Delete note and remove it from synced articles cache' command. </sub> |
 | `article_title` | Title of the article |
 | `original_link` | Link to the source article |
 | `created_at` | Creation date of the article in Wallabag |
 | `published_at` | When the article was originally published according to Wallabag |
-| `updated_at` | Last modification date of the article in Wallabag <sub><br>Wallabag API seems not to change this field when modifying annotations.</sub> |
+| `updated_at` | Last modification date of the article in Wallabag RemoveCurrentFromSyncedArticlesCacheCommand |
 | `wallabag_link` | Link to the article in Wallabag |
 | `content` | HTML content extracted by wallabag |
 | `pdf_link` | An Obsidian wikilink to the exported pdf file. <sub><br> Only populated if the PDF export option is choosen.</sub> |

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ By default this plugin offers two builtin templates; one for inserting the conte
 You can use a custom template, in that case plugin will pass the following variables.
 | Variable | Description |
 |:----------------|:-------------------------------------------------------------------------------------------------------------------|
+| `id` | Wallabag ID of the article (Useful for scripting) |
 | `article_title` | Title of the article |
 | `original_link` | Link to the source article |
 | `created_at` | Creation date of the article in Wallabag |
+| `published_at` | When the article was originally published according to Wallabag |
+| `updated_at` | Last modification date of the article in Wallabag <sub><br>Wallabag API seems not to change this field when modifying annotations.</sub> |
 | `wallabag_link` | Link to the article in Wallabag |
 | `content` | HTML content extracted by wallabag |
 | `pdf_link` | An Obsidian wikilink to the exported pdf file. <sub><br> Only populated if the PDF export option is choosen.</sub> |

--- a/src/command/DeleteNoteAndRemoveFromSyncedCacheCommand.ts
+++ b/src/command/DeleteNoteAndRemoveFromSyncedCacheCommand.ts
@@ -1,0 +1,45 @@
+import WallabagPlugin from 'main';
+import { Command, Notice, parseFrontMatterEntry, TFile } from 'obsidian';
+
+export default class DeleteNoteAndRemoveFromSyncedCacheCommand implements Command {
+  id = 'delete-and-remove-from-synced-articles-cache';
+  name = 'Delete note and remove it from synced articles cache';
+
+  private plugin: WallabagPlugin;
+  private syncedFilePath: string;
+
+  constructor(plugin: WallabagPlugin) {
+    this.plugin = plugin;
+    this.syncedFilePath = `${this.plugin.manifest.dir}/.synced`;
+  }
+
+  async callback() {
+    const notice = new Notice('Delete note and remove it from synced articles cache.');
+    const currentNote = this.plugin.app.workspace.getActiveFile();
+    if (currentNote instanceof TFile) {
+      // Get Wallabag ID from frontmatter in file.
+      const cmeta = this.plugin.app.metadataCache.getFileCache(currentNote);
+      let wallabag_id = parseFrontMatterEntry(cmeta?.frontmatter, 'wallabag_id');
+      if (wallabag_id === null) { new Notice('Error: Wallabag ID not found in frontmatter. Please see plugin docs.'); notice.hide(); return; }
+      wallabag_id = Number(wallabag_id);
+      if (isNaN(wallabag_id) || wallabag_id === 0) { new Notice('Error: Wallabag ID frontmatter doesn\'t seem to be a valid number.'); notice.hide(); return; }
+
+      // Remove current ID from .synced file.
+      const exists = await this.plugin.app.vault.adapter.exists(this.syncedFilePath);
+      if (exists) {
+        const syncedIds = await this.plugin.app.vault.adapter.read(this.syncedFilePath).then(JSON.parse);
+        syncedIds.forEach((item: number, index: number) => {
+          if (item === wallabag_id) { syncedIds.splice(index, 1); }
+        });
+        await this.plugin.app.vault.adapter.write(this.syncedFilePath, JSON.stringify(syncedIds));
+      }
+
+      await this.plugin.app.vault.trash(currentNote, false);
+      new Notice('Note is moved to trash and removed from synced articles cache.');
+
+    } else {
+      new Notice('Error: Current item is not a note.');
+    }
+    notice.hide();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import DeleteNoteAndRemoveFromSyncedCacheCommand from 'command/DeleteNoteAndRemoveFromSyncedCacheCommand';
 import ClearSyncedArticlesCacheCommand from 'command/ResetSyncedArticlesCacheCommand';
 import SyncArticlesCommand from 'command/SyncArticlesCommand';
 import { Notice, Plugin } from 'obsidian';
@@ -19,6 +20,7 @@ export default class WallabagPlugin extends Plugin {
     this.addSettingTab(new WallabagSettingTab(this.app, this, _ => this.authenticated));
     this.addCommand(syncArticlesCommand);
     this.addCommand(new ClearSyncedArticlesCacheCommand(this));
+    this.addCommand(new DeleteNoteAndRemoveFromSyncedCacheCommand(this));
 
     if (this.settings.syncOnStartup === 'true') {
       syncArticlesCommand.callback();

--- a/src/note/NoteTemplate.ts
+++ b/src/note/NoteTemplate.ts
@@ -11,9 +11,12 @@ export default class NoteTemplate {
   fill(wallabagArticle: WallabagArticle, serverBaseUrl: string, convertHtmlToMarkdown: string, tagFormat: string, pdfLink = ''): string {
     const annotations = wallabagArticle.annotations.map(a => '> ' + a.quote + (a.text ? '\n\n' + a.text : '')).join('\n\n');
     const variables: {[key: string]: string} = {
+      '{{id}}': wallabagArticle.id.toString(),
       '{{article_title}}': wallabagArticle.title,
       '{{original_link}}': wallabagArticle.url,
       '{{created_at}}': wallabagArticle.createdAt,
+      '{{published_at}}': wallabagArticle.publishedAt,
+      '{{updated_at}}': wallabagArticle.updatedAt,
       '{{wallabag_link}}': `${serverBaseUrl}/view/${wallabagArticle.id}`,
       '{{content}}': convertHtmlToMarkdown === 'true' ? htmlToMarkdown(wallabagArticle.content) : wallabagArticle.content,
       '{{pdf_link}}': pdfLink,

--- a/src/settings/WallabagSettingTab.ts
+++ b/src/settings/WallabagSettingTab.ts
@@ -47,17 +47,7 @@ export class WallabagSettingTab extends PluginSettingTab {
         name: 'Article note template file',
         desc: sanitizeHTMLToDom(
           'The template file that will be used for the new articles.<br> ' +
-          '<code>{{article_title}}</code>: Title of the article.<br>' +
-          '<code>{{original_link}}</code>: Link to the original article.<br>' +
-          '<code>{{created_at}}</code>: Creation date of the article in Wallabag.<br>' +
-          '<code>{{wallabag_link}}</code>: Link to the Wallabag article.<br>' +
-          '<code>{{content}}</code>: HTML Content extracted by Wallabag. <br>' +
-          '<code>{{pdf_link}}</code>: An Obsidian link to the exported pdf.' +
-          '<code>{{tags}}</code>: Tags of the article.<br>' +
-          '<code>{{reading_time}}</code>: Reading time of the article.<br>' +
-          '<code>{{preview_picture}}</code>: Preview picture of the article.<br>' +
-          '<code>{{domain_name}}</code>: Domain name of the article.<br>' +
-          '<code>{{annotations}}</code>: Created annotations of the article.<br>'
+          'See <a href="https://github.com/huseyz/obsidian-wallabag">documentation</a> for examples.'
         ),
         get: () => this.plugin.settings.articleTemplate,
         set: this.updateSetting('articleTemplate')

--- a/src/wallabag/WallabagAPI.ts
+++ b/src/wallabag/WallabagAPI.ts
@@ -19,6 +19,8 @@ export interface WallabagArticle {
   url: string,
   content: string,
   createdAt: string,
+  publishedAt: string;
+  updatedAt: string;
   readingTime: string,
   previewPicture: string,
   domainName: string
@@ -98,6 +100,8 @@ export default class WallabagAPI {
       url: article['url'],
       content: article['content'],
       createdAt: article['created_at'],
+      updatedAt: article['updated_at'],
+      publishedAt: article['published_at'],
       readingTime: article['reading_time'],
       previewPicture: article['preview_picture'],
       domainName: article['domain_name'],


### PR DESCRIPTION
This branch builds on of https://github.com/huseyz/obsidian-wallabag/pull/26 so you will see some changes from that PR in this diff.

A command to remove the current note from the synced items cache and then deletes the note. You can use this to fetch new changes for one specific note.

@gwutz Sorry for tagging you once more, but again this might be relevant to you :p
