### PR TITLE
fix sync archived article

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There are various settings under the plugin settings you can use to personalize 
 | Article Notes Folder                                   | Define the folder you want synced notes will be created. If empty notes will be created at the vault root.          |
 | Article Note Template                                  | Use to pass a custom template for notes. See the [Templating](#templating) for more details.                        |
 | Sync on startup                                        | If enabled, articles will be synced on startup.                                                                     |
-| Sync archived articles                                 | If enabled, archived articles will be synced                                                                        |
+| Sync archived articles                                 | If enabled, archived articles will also be synced.                                                                  |
 | Export as PDF                                          | If enabled synced articles will be exported as PDFs.                                                                |
 | Convert HTML Content extracted by Wallabag to Markdown | If enabled the content of the Wallabag article will be converted to markdown before being used for the new article. |
 | Archive article after sync                             | If enabled the article will be archived after being synced.                                                         |
@@ -87,4 +87,3 @@ Relative to `[VAULT]/.obsidian/plugins/obsidian-wallabag`:
 
 - `.synced`: List of all id's that have already been downloaded. Plugin will not attempt to download these articles again until cleared.
 - `.__wallabag_token__`: Authentication credentials for Wallabag.
-

--- a/src/command/SyncArticlesCommand.ts
+++ b/src/command/SyncArticlesCommand.ts
@@ -60,7 +60,7 @@ export default class SyncArticlesCommand implements Command {
 
     const fetchNotice = new Notice('Syncing from Wallabag..');
 
-    const articles = await this.plugin.api.fetchArticles(this.plugin.settings.syncArchived === 'true' ? 1 : 0);
+    const articles = await this.plugin.api.fetchArticles(this.plugin.settings.syncArchived === 'true' ? true : false);
     const newIds = await Promise.all(articles
       .filter((article) => !previouslySynced.contains(article.id))
       .map(async (article) => {

--- a/src/settings/WallabagSettingTab.ts
+++ b/src/settings/WallabagSettingTab.ts
@@ -69,7 +69,7 @@ export class WallabagSettingTab extends PluginSettingTab {
 
     new Setting(this.containerEl)
       .setName('Sync archived articles')
-      .setDesc('If enabled, archived articles will be synced.')
+      .setDesc('If enabled, archived articles will also be synced.')
       .addToggle(async (toggle) => {
         toggle
           .setValue(this.plugin.settings.syncArchived === 'true')

--- a/src/wallabag/WallabagAPI.ts
+++ b/src/wallabag/WallabagAPI.ts
@@ -145,14 +145,15 @@ export default class WallabagAPI {
     });
   }
 
-  async fetchArticles(archive = 0, page = 1, results: WallabagArticle[] = []): Promise<WallabagArticle[]> {
-    const url = `${this.plugin.settings.serverUrl}/api/entries.json?archive=${archive}&page=${page}&tags=${this.plugin.settings.tag}`;
+  async fetchArticles(syncArchivedArticles = false, page = 1, results: WallabagArticle[] = []): Promise<WallabagArticle[]> {
+    const archiveParam = syncArchivedArticles ? '' : '&archive=0';
+    const url = `${this.plugin.settings.serverUrl}/api/entries.json?page=${page}&tags=${this.plugin.settings.tag}${archiveParam}`;
     return this.tokenRefreshingFetch(url).then((value) => {
       const response = this.convertWallabagArticlesResponse(value);
       if (response.pages === response.page) {
         return [...results, ...response.articles];
       } else {
-        return this.fetchArticles(archive, page+1, [...results, ...response.articles]);
+        return this.fetchArticles(syncArchivedArticles, page+1, [...results, ...response.articles]);
       }
     });
   }


### PR DESCRIPTION
When I added the setting to sync archived articles, I wanted to keep the original behavior (sync non-archived articles) and add to it as a behavior to also sync archived articles.

I recently found that when the archived articles sync flag was enabled, only archived articles were synced. So here is a fix to apply the intended behavior.

I've also changed the parameter description to better reflect its usage.