### PR TITLE
Sync unread and archived articles behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ There are various settings under the plugin settings you can use to personalize 
 | Article Notes Folder                                   | Define the folder you want synced notes will be created. If empty notes will be created at the vault root.          |
 | Article Note Template                                  | Use to pass a custom template for notes. See the [Templating](#templating) for more details.                        |
 | Sync on startup                                        | If enabled, articles will be synced on startup.                                                                     |
-| Sync archived articles                                 | If enabled, archived articles will also be synced.                                                                  |
+| Sync unread articles                                   | If enabled, unread articles will be synced.                                                                         |
+| Wallabag unread article notes folder location          | (optional) Choose the location where the unread synced article notes will be created.                               |
+| Sync archived articles                                 | If enabled, archived articles will be synced.                                                                       |
+| Wallabag archived article notes folder location        | (optional) Choose the location where the archived synced article notes will be created.                             |
 | Export as PDF                                          | If enabled synced articles will be exported as PDFs.                                                                |
 | Convert HTML Content extracted by Wallabag to Markdown | If enabled the content of the Wallabag article will be converted to markdown before being used for the new article. |
 | Archive article after sync                             | If enabled the article will be archived after being synced.                                                         |
@@ -50,6 +53,8 @@ You can use a custom template, in that case plugin will pass the following varia
 | `reading_time` | Reading time of the article |
 | `preview_picture` | link to preview picture of the article |
 | `domain_name` | Link to the source domain article |
+| `is_archived` | Whether the article is archived or not |
+| `is_starred` | Whether the article is starred or not |
 
 I mainly use the template to export pdfs and use [Annotator]() to read using the following template.
 

--- a/src/command/SyncArticlesCommand.ts
+++ b/src/command/SyncArticlesCommand.ts
@@ -33,6 +33,16 @@ export default class SyncArticlesCommand implements Command {
     return new NoteTemplate(template);
   }
 
+  private getFolder(wallabagArticle: WallabagArticle): string {
+    if (wallabagArticle.isArchived && this.plugin.settings.archivedFolder !== '') {
+      return this.plugin.settings.archivedFolder;
+    } else if (!wallabagArticle.isArchived && this.plugin.settings.unreadFolder !== '') {
+      return this.plugin.settings.unreadFolder;
+    } else {
+      return this.plugin.settings.folder;
+    }
+  }
+
   private getFilename(wallabagArticle: WallabagArticle): string {
     const filename = wallabagArticle.title.replaceAll(/[\\,#%&{}/*<>$"@.?]/g, ' ').replaceAll(/[:|]/g, ' ');
     if (this.plugin.settings.idInTitle === 'true') {
@@ -60,13 +70,14 @@ export default class SyncArticlesCommand implements Command {
 
     const fetchNotice = new Notice('Syncing from Wallabag..');
 
-    const articles = await this.plugin.api.fetchArticles(this.plugin.settings.syncArchived === 'true' ? true : false);
+    const articles = await this.plugin.api.fetchArticles(this.plugin.settings.syncUnRead === 'true' ? true : false, this.plugin.settings.syncArchived === 'true' ? true : false);
     const newIds = await Promise.all(articles
       .filter((article) => !previouslySynced.contains(article.id))
       .map(async (article) => {
+        const folder = this.getFolder(article);
         if (this.plugin.settings.downloadAsPDF !== 'true') {
           const template = this.plugin.settings.articleTemplate === '' ? DefaultTemplate : await this.getUserTemplate();
-          const filename = normalizePath(`${this.plugin.settings.folder}/${this.getFilename(article)}.md`);
+          const filename = normalizePath(`${folder}/${this.getFilename(article)}.md`);
           const content = template.fill(article, this.plugin.settings.serverUrl, this.plugin.settings.convertHtmlToMarkdown, this.plugin.settings.tagFormat);
           await this.createNoteIfNotExists(filename, content);
         } else {
@@ -75,7 +86,7 @@ export default class SyncArticlesCommand implements Command {
           await this.plugin.app.vault.adapter.writeBinary(pdfFilename, pdf);
           if (this.plugin.settings.createPDFNote) {
             const template = this.plugin.settings.articleTemplate === '' ? PDFTemplate : await this.getUserTemplate();
-            const filename = normalizePath(`${this.plugin.settings.folder}/${this.getFilename(article)}.md`);
+            const filename = normalizePath(`${folder}/${this.getFilename(article)}.md`);
             const content = template.fill(article, this.plugin.settings.serverUrl, this.plugin.settings.tagFormat, pdfFilename);
             await this.createNoteIfNotExists(filename, content);
           }

--- a/src/command/SyncArticlesCommand.ts
+++ b/src/command/SyncArticlesCommand.ts
@@ -65,7 +65,11 @@ export default class SyncArticlesCommand implements Command {
     if (!this.plugin.authenticated) {
       new Notice('Please authenticate with Wallabag first.');
       return;
+    } else if (this.plugin.settings.syncUnRead === 'false' && this.plugin.settings.syncArchived === 'false') {
+      new Notice('Please select at least one type of article to sync.');
+      return;
     }
+
     const previouslySynced = await this.readSynced();
 
     const fetchNotice = new Notice('Syncing from Wallabag..');

--- a/src/note/NoteTemplate.ts
+++ b/src/note/NoteTemplate.ts
@@ -25,7 +25,9 @@ export default class NoteTemplate {
       '{{reading_time}}': wallabagArticle.readingTime,
       '{{preview_picture}}': wallabagArticle.previewPicture,
       '{{domain_name}}': wallabagArticle.domainName,
-      '{{annotations}}': annotations
+      '{{annotations}}': annotations,
+      '{{is_archived}}': wallabagArticle.isArchived ? 'true' : 'false',
+      '{{is_starred}}': wallabagArticle.isStarred ? 'true' : 'false',
     };
     let noteContent = this.content;
     Object.keys(variables).forEach((key) => {

--- a/src/settings/WallabagSettings.ts
+++ b/src/settings/WallabagSettings.ts
@@ -11,7 +11,10 @@ export interface WallabagSettings {
   archiveAfterSync: string;
   syncOnStartup: string;
   syncArchived: string;
+  syncUnRead: string;
   tagFormat: string;
+  unreadFolder: string;
+  archivedFolder: string;
 }
 
 export const DEFAULT_SETTINGS: WallabagSettings = {
@@ -27,5 +30,8 @@ export const DEFAULT_SETTINGS: WallabagSettings = {
   archiveAfterSync: 'false',
   syncOnStartup: 'false',
   syncArchived: 'false',
+  syncUnRead: 'true',
   tagFormat: 'csv',
+  unreadFolder: '',
+  archivedFolder: '',
 };


### PR DESCRIPTION
Some modification on syncing behavior, as mentionned in : 
- Fix https://github.com/huseyz/obsidian-wallabag/issues/31 (@legolasdimir)
- https://github.com/huseyz/obsidian-wallabag/pull/29 (@peterrus)

Modifications : 
- New param to sync unread article.  The default is to true (same behavior as before).
- Added folder params for unread and for archived articles.
- Added is_starred and is_archived templating variables.
- Added some titles, and reordoring in Setting Tab.
